### PR TITLE
small routing fix

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -28,7 +28,7 @@ router.get('/create', function(req, res, next) {
 });
 
 router.get('/login', function(req, res, next) {
-   if(req.isAuthenticated()) res.redirect('/');
+   if(req.isAuthenticated()) return res.redirect('/');
    res.render('signin', {title: 'Sign In'});
 });
 


### PR DESCRIPTION
So this one gave me a bit of headache (I was following this example pretty closely in my own project) - if you don't explicitly _return_ after the redirect, express just keeps on chugging along and tries to run the next line, which isn't what you want, _and_ can throw a nasty error, just saying "Cannot set headers after they are sent to the client".

Small fix, but hopefully someone else reading this example can save some headache trying to figure this out xP